### PR TITLE
solve problems caused by bootstrap.css.map

### DIFF
--- a/vendor/assets/stylesheets/bootstrap/bootstrap.scss
+++ b/vendor/assets/stylesheets/bootstrap/bootstrap.scss
@@ -7718,5 +7718,3 @@ button.close {
     display: none !important;
   }
 }
-
-/*# sourceMappingURL=bootstrap.css.map */


### PR DESCRIPTION
Delete last line in `/vendor/assets/stylesheets/bootstrap/bootstrap.scss`
`
/*# sourceMappingURL=bootstrap.css.map */ 
`
Which could cause `ActionController::RoutingError (No route matches [GET] "/assets/bootstrap.css.map"): ` In Rails 5.0.2.
